### PR TITLE
Use go mod in workflow to determine go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version-file: go.mod
+        check-latest: true
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
- while fixing tps/cc-uploader, figured it would be good to be consistent